### PR TITLE
Add learning paths pages and navigation badge

### DIFF
--- a/app/paths/[slug]/page.tsx
+++ b/app/paths/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { CH1, SubTitle } from "@/components/custom-typo";
 import { PathStep } from "@/components/path-step";
 import { Badge } from "@/components/ui/badge";
 import { paths } from "@/config/paths";
+import { Path } from "@/types/path";
 
 export default function PathDetailPage({
   params,
@@ -33,4 +34,10 @@ export default function PathDetailPage({
       </div>
     </div>
   );
+}
+
+export async function generateStaticParams() {
+  return paths.map((path: Path) => ({
+    slug: path.href,
+  }));
 }

--- a/app/paths/[slug]/page.tsx
+++ b/app/paths/[slug]/page.tsx
@@ -1,0 +1,36 @@
+import { notFound } from "next/navigation";
+
+import { CH1, SubTitle } from "@/components/custom-typo";
+import { PathStep } from "@/components/path-step";
+import { Badge } from "@/components/ui/badge";
+import { paths } from "@/config/paths";
+
+export default function PathDetailPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const path = paths.find((p) => p.href === params.slug);
+
+  if (!path) {
+    return notFound();
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Badge variant="secondary">Difficulty {path.difficulty}</Badge>
+          {path.starred && <Badge>Popular</Badge>}
+        </div>
+        <CH1 text={path.title} />
+        <SubTitle text={path.synopsis} />
+      </div>
+      <div className="space-y-4">
+        {path.steps.map((step, index) => (
+          <PathStep key={`${path.href}-${step.name}`} step={step} index={index} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/paths/page.tsx
+++ b/app/paths/page.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+import { CH1, SubTitle } from "@/components/custom-typo";
+import { PathCard } from "@/components/path-card";
+import { paths } from "@/config/paths";
+
+export default function PathsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <CH1 text="Learning Paths" />
+        <SubTitle text="Follow structured journeys that mix videos, reads, and games." />
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {paths.map((path) => (
+          <PathCard key={path.href} path={path} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/blog-component.tsx
+++ b/components/blog-component.tsx
@@ -1,11 +1,12 @@
 "use client";
 import React, { useState, useMemo } from "react";
 import { UnifiedCard } from "@/components/card-component";
-import { useProgressStore } from '@/stores/progress-store';
+import { useProgressStore } from "@/stores/progress-store";
 import {
   UnifiedContent,
   isGame,
   isArticle,
+  isLink,
   sortLevel,
 } from "@/types/unifiedContent";
 
@@ -25,9 +26,14 @@ export function BlogComponent({
   const filteredAndSortedContents = useMemo(() => {
     return contents
       .filter((c) => {
+        const title = c.content.title?.toLowerCase?.() ?? "";
+        const synopsis =
+          "synopsis" in c.content && c.content.synopsis
+            ? c.content.synopsis.toLowerCase()
+            : "";
         const matchesSearch =
-          c.content.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          c.content.synopsis.toLowerCase().includes(searchTerm.toLowerCase());
+          title.includes(searchTerm.toLowerCase()) ||
+          synopsis.includes(searchTerm.toLowerCase());
         const matchesType =
           contentType === "all" ||
           (contentType === "game" && isGame(c)) ||
@@ -92,7 +98,7 @@ export function BlogComponent({
       )}
       <div className="max-w-full w-full gap-2 flex flex-col md:grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3">
         {filteredAndSortedContents.map((c: UnifiedContent) => (
-          <UnifiedCard key={c.content.title} content={c} />
+          !isLink(c) && <UnifiedCard key={c.content.title} content={c} />
         ))}
       </div>
     </div>

--- a/components/card-component.tsx
+++ b/components/card-component.tsx
@@ -20,8 +20,15 @@ export function UnifiedCard(props: { content: UnifiedContent }) {
   const [done, setDone] = React.useState(false);
   const { isContentCompleted } = useProgressStore();
   const { content } = props;
-  const item = content.content;
-  React.useEffect(() => setDone(isContentCompleted(item.href)), [item]);
+  const isPlayableContent = isGame(content) || isArticle(content);
+  const item = isPlayableContent ? content.content : null;
+
+  React.useEffect(() => {
+    if (!item) return;
+    setDone(isContentCompleted(item.href));
+  }, [item, isContentCompleted]);
+
+  if (!item || (!isGame(content) && !isArticle(content))) return null;
 
   if (!item) return null;
 

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 
 import { siteConfig } from "@/config/site";
 import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
 
 export function MainNav() {
   const pathname = usePathname();
@@ -37,6 +38,17 @@ export function MainNav() {
           <div className="flex items-center">
           Games{" "} <ControllerIcon size={16} />
           </div>
+        </a>
+        <a
+          href="/paths"
+          className={cn(
+            "relative flex items-center gap-2",
+            "transition-colors hover:text-foreground/80",
+            pathname === "/paths" ? "text-foreground" : "text-foreground/60"
+          )}
+        >
+          Paths
+          <Badge className="text-[10px]">New</Badge>
         </a>
         <a
           href="/blogs"

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -12,6 +12,7 @@ import { Icons } from "@/components/icons"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
+import { Badge } from "@/components/ui/badge"
 
 export function MobileNav() {
   const [open, setOpen] = React.useState(false)
@@ -46,7 +47,10 @@ export function MobileNav() {
                     href={item.href}
                     onOpenChange={setOpen}
                   >
-                    {item.title}
+                    <span className="flex items-center gap-2">
+                      {item.title}
+                      {item.isNew && <Badge className="text-[10px]">New</Badge>}
+                    </span>
                   </MobileLink>
                 )
             )}

--- a/components/path-card.tsx
+++ b/components/path-card.tsx
@@ -1,0 +1,33 @@
+import { Star } from "lucide-react";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Path } from "@/types/path";
+import { cn } from "@/lib/utils";
+
+export function PathCard({ path }: { path: Path }) {
+  return (
+    <Card
+      className={cn(
+        "flex h-full flex-col gap-2 bg-muted",
+        path.starred && "shadow-lg shadow-primary/30"
+      )}
+    >
+      <a href={`/paths/${path.href}`} className="flex h-full flex-col gap-2 p-4">
+        <CardHeader className="p-0">
+          <CardTitle className="flex items-center gap-2 text-xl">
+            {path.title}
+            {path.starred && <Star className="h-4 w-4 fill-primary text-primary" />}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3 p-0">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Badge variant="secondary">Difficulty {path.difficulty}</Badge>
+            {path.disabled && <Badge variant="outline">Coming soon</Badge>}
+          </div>
+          <p className="text-sm text-muted-foreground">{path.synopsis}</p>
+        </CardContent>
+        <CardFooter className="p-0 text-sm font-semibold text-primary">Start path →</CardFooter>
+      </a>
+    </Card>
+  );
+}

--- a/components/path-step.tsx
+++ b/components/path-step.tsx
@@ -1,0 +1,36 @@
+import { LinkComponent } from "@/components/custom-link-component";
+import { UnifiedCard } from "@/components/card-component";
+import { Badge } from "@/components/ui/badge";
+import { PathStep as LearningPathStep } from "@/types/path";
+import { UnifiedContent, isLink } from "@/types/unifiedContent";
+
+export function PathStep({
+  step,
+  index,
+}: {
+  step: LearningPathStep;
+  index: number;
+}) {
+  return (
+    <div className="space-y-3 rounded-lg border border-border p-4">
+      <div className="flex items-center gap-2">
+        <Badge variant="secondary">Step {index + 1}</Badge>
+        <h3 className="text-lg font-semibold">{step.name}</h3>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {step.content.map((content: UnifiedContent, i: number) =>
+          isLink(content) ? (
+            <div
+              key={`${content.content.title}-${i}`}
+              className="flex h-full items-center rounded-lg border border-dashed border-border bg-muted/50 p-3"
+            >
+              <LinkComponent link={content.content} />
+            </div>
+          ) : (
+            <UnifiedCard key={`${content.content.href}-${i}`} content={content} />
+          )
+        )}
+      </div>
+    </div>
+  );
+}

--- a/config/docs.ts
+++ b/config/docs.ts
@@ -24,6 +24,11 @@ export const docsConfig: DocsConfig = {
             href: "/games",
         },
         {
+            title: "Paths",
+            href: "/paths",
+            isNew: true,
+        },
+        {
             title: "GitHub",
             href: siteConfig.links.github,
             external: true,

--- a/config/paths.ts
+++ b/config/paths.ts
@@ -1,0 +1,102 @@
+import { Path } from "@/types/path";
+import { LINK_TYPE, CustomLink } from "@/types/link";
+import { blogsDict } from "@/config/blogs";
+import { resolveContent, findGameByHref } from "@/utils/pathsUtils";
+
+const quickStartVideo = new CustomLink(
+  "https://www.youtube.com/watch?v=kqtD5dpn9C8",
+  "Python Explained in 5 Minutes",
+  true,
+  LINK_TYPE.YOUTUBE_VIDEO
+);
+
+const debuggingWalkthrough = new CustomLink(
+  "https://www.youtube.com/watch?v=Qd8JT0bnJGs",
+  "Debugging Python Like a Pro",
+  true,
+  LINK_TYPE.YOUTUBE_VIDEO
+);
+
+const basePaths: Path[] = [
+  {
+    href: "python-basics",
+    title: "Python Basics Path",
+    difficulty: 1,
+    synopsis: "Learn Python fundamentals through hands-on practice.",
+    starred: true,
+    steps: [
+      {
+        name: "Getting Started",
+        content: [
+          { type: "article", content: blogsDict.intro },
+          { type: "link", content: quickStartVideo },
+          { type: "game", content: findGameByHref("introduction") },
+        ],
+      },
+      {
+        name: "Core Building Blocks",
+        content: [
+          resolveContent({ type: "article", href: "tuto-for-basics" }),
+          { type: "game", content: findGameByHref("variable-declaration-1") },
+          { type: "game", content: findGameByHref("loop-1") },
+          { type: "link", content: new CustomLink("https://www.python.org/about/gettingstarted/", "Official Python guide", true) },
+        ],
+      },
+      {
+        name: "Momentum",
+        content: [
+          resolveContent({ type: "article", href: "avoid-tutorial-hell" }),
+          { type: "game", content: findGameByHref("list-append-1") },
+          { type: "link", content: new CustomLink("https://www.youtube.com/watch?v=rfscVS0vtbw", "Full Python course (freeCodeCamp)", true, LINK_TYPE.YOUTUBE_VIDEO) },
+        ],
+      },
+    ],
+  },
+  {
+    href: "debugging-essentials",
+    title: "Debugging & Problem Solving",
+    difficulty: 2,
+    synopsis: "Level up with debugging strategies, common pitfalls, and guided practice.",
+    steps: [
+      {
+        name: "Mindset & Tools",
+        content: [
+          resolveContent({ type: "article", href: "how-to-debug-python" }),
+          { type: "link", content: debuggingWalkthrough },
+          { type: "link", content: new CustomLink("https://docs.python.org/3/library/pdb.html", "Official pdb guide", true) },
+        ],
+      },
+      {
+        name: "Debugging Practice",
+        content: [
+          { type: "game", content: findGameByHref("variable-assignment-typing-1") },
+          { type: "game", content: findGameByHref("shopping-cart-calculation-1") },
+          { type: "game", content: findGameByHref("string-formatting-syntax") },
+        ],
+      },
+      {
+        name: "Avoiding Pitfalls",
+        content: [
+          resolveContent({ type: "article", href: "how-will-learning-python-help-me" }),
+          resolveContent({ type: "article", href: "how_many_months" }),
+          resolveContent({ type: "article", href: "is_it_bad_to_learn_python_with_chatpgt" }),
+        ],
+      },
+    ],
+  },
+];
+
+const existingHref: string[] = [];
+export const pathsDict: { [key: string]: Path } = basePaths.reduce(
+  (acc: { [key: string]: Path }, path: Path) => {
+    if (existingHref.includes(path.href)) {
+      throw new TypeError(`HREF : ${path.href} already exists.`);
+    }
+    existingHref.push(path.href);
+    acc[path.href] = path;
+    return acc;
+  },
+  {}
+);
+
+export const paths: Path[] = Object.values(pathsDict).filter((path) => !path.disabled);

--- a/types/nav.ts
+++ b/types/nav.ts
@@ -2,17 +2,20 @@ export class MainNavItem {
     disabled?: boolean;
     external?: boolean;
     items?: MainNavItem[];
+    isNew?: boolean;
     href: string;
     title: string;
 
     constructor(disabled: boolean,
                 external: boolean,
+                isNew: boolean,
                 href: string,
                 title: string,
                 items: MainNavItem[]) {
         this.disabled = disabled;
         this.external = external;
         this.items = items;
+        this.isNew = isNew;
         this.href = href;
         this.title = title;
     }

--- a/types/path.ts
+++ b/types/path.ts
@@ -1,0 +1,17 @@
+import { UnifiedContent } from "@/types/unifiedContent";
+
+export interface PathStep {
+  name: string;
+  content: UnifiedContent[];
+  order?: number;
+}
+
+export interface Path {
+  href: string;
+  title: string;
+  difficulty: number;
+  synopsis: string;
+  steps: PathStep[];
+  disabled?: boolean;
+  starred?: boolean;
+}

--- a/types/unifiedContent.ts
+++ b/types/unifiedContent.ts
@@ -1,32 +1,43 @@
 import { Game } from "@/types/game";
 import { Article } from "@/types/article";
+import { CustomLink } from "@/types/link";
 
-export type UnifiedContent = {
-  type: 'game' | 'article';
-  content: Game | Article;
-};
+export type UnifiedContent =
+  | { type: "game"; content: Game }
+  | { type: "article"; content: Article }
+  | { type: "link"; content: CustomLink };
 
-export function isGame(content: UnifiedContent): content is { type: 'game', content: Game } {
-  return content.type === 'game';
+export function isGame(
+  content: UnifiedContent
+): content is { type: "game"; content: Game } {
+  return content.type === "game";
 }
 
-export function isArticle(content: UnifiedContent): content is { type: 'article', content: Article } {
-  return content.type === 'article';
+export function isArticle(
+  content: UnifiedContent
+): content is { type: "article"; content: Article } {
+  return content.type === "article";
+}
+
+export function isLink(
+  content: UnifiedContent
+): content is { type: "link"; content: CustomLink } {
+  return content.type === "link";
 }
 
 export function sortLevel(a: UnifiedContent, b: UnifiedContent): number {
-    // Articles always come after Games
-    if (isArticle(a) && isGame(b)) return 1;
-    if (isGame(a) && isArticle(b)) return -1;
+  // Articles and Links always come after Games
+  if ((isArticle(a) || isLink(a)) && isGame(b)) return 1;
+  if (isGame(a) && (isArticle(b) || isLink(b))) return -1;
 
-    // If both are Articles, maintain their current order
-    if (isArticle(a) && isArticle(b)) return 0;
+  // If both are non-games, maintain their current order
+  if (!isGame(a) && !isGame(b)) return 0;
 
-    // If both are Games, compare their levels
-    if (isGame(a) && isGame(b)) {
-        return (a.content as Game).level - (b.content as Game).level;
-    }
+  // If both are Games, compare their levels
+  if (isGame(a) && isGame(b)) {
+    return (a.content as Game).level - (b.content as Game).level;
+  }
 
-    // This should never happen if all UnifiedContent are either Games or Articles
-    return 0;
+  // This should never happen if all UnifiedContent are either Games, Articles, or Links
+  return 0;
 }

--- a/utils/pathsUtils.ts
+++ b/utils/pathsUtils.ts
@@ -1,0 +1,34 @@
+import { Article } from "@/types/article";
+import { Game } from "@/types/game";
+import { UnifiedContent } from "@/types/unifiedContent";
+import { blogs } from "@/config/blogs";
+import { games } from "@/config/games";
+
+export type ContentReference =
+  | { type: "game"; href: string }
+  | { type: "article"; href: string }
+  | UnifiedContent;
+
+export function findGameByHref(href: string): Game {
+  const game = games.find((g) => g.href === href);
+  if (!game) {
+    throw new Error(`Game with href ${href} not found.`);
+  }
+  return game;
+}
+
+export function findArticleByHref(href: string): Article {
+  const article = blogs.find((b) => b.href === href);
+  if (!article) {
+    throw new Error(`Article with href ${href} not found.`);
+  }
+  return article;
+}
+
+export function resolveContent(reference: ContentReference): UnifiedContent {
+  if ("content" in reference) return reference;
+  if (reference.type === "game") {
+    return { type: "game", content: findGameByHref(reference.href) };
+  }
+  return { type: "article", content: findArticleByHref(reference.href) };
+}


### PR DESCRIPTION
## Summary
- add learning path types, utilities, and seed data for curated journeys
- create listing and detail pages with reusable path cards and step renderers
- update navigation and unified content handling to surface the new Paths section

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69445f9a3a20832abc346f44a0c105d4)